### PR TITLE
Use port 2375 for DOCKER_OPTS in the Linux without systemd doc

### DIFF
--- a/src/main/scala/ui/pages/SettingsPage.scala
+++ b/src/main/scala/ui/pages/SettingsPage.scala
@@ -166,7 +166,7 @@ object SettingsPageRender {
                   <.h3("Linux without systemd:"),
                   <.ul(
                     <.li("Edit ", <.code("/etc/default/docker"), " to allow connections adding:", <.br(),
-                      <.code("DOCKER_OPTS='-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock'")
+                      <.code("DOCKER_OPTS='-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock'")
                     ),
                     <.li("Restart the Docker service using:", <.br(),
                       <.code("sudo service docker restart")


### PR DESCRIPTION
The doc suggests binding docker to port 4243 but then asking you to verify it in the browser on port 2375.
