### PR TITLE
optimize container list api call

### DIFF
--- a/src/main/scala/api/DockerClient.scala
+++ b/src/main/scala/api/DockerClient.scala
@@ -179,7 +179,7 @@ case class DockerClient(connection: Connection) {
 
   // https://docs.docker.com/reference/api/docker_remote_api_v1.17/#list-containers
   private def containers(all: Boolean): Future[Seq[Container]] =
-    Ajax.get(s"$url/containers/json?all=$all&size=true", timeout = HttpTimeOut).map { xhr =>
+    Ajax.get(s"$url/containers/json?all=$all", timeout = HttpTimeOut).map { xhr =>
       log.info("[dockerClient.containers]")
       read[Seq[Container]](xhr.responseText)
     }


### PR DESCRIPTION
By removing size parameter the container list generating much faster. Do we need the size info on this page?
