### PR TITLE
Persist and display container run command

### DIFF
--- a/src/main/scala/api/ConfigStorage.scala
+++ b/src/main/scala/api/ConfigStorage.scala
@@ -45,6 +45,15 @@ object ConfigStorage {
     p.future
   }
 
+  private def remove(key: String): Future[Unit] = {
+    log.info(s"Removing $key")
+    val p = Promise[Unit]()
+    chrome.storage.local.remove(key, { () =>
+      p.success(log.info(s"'$key' Removed"))
+    })
+    p.future
+  }
+
   def defaultUrl: Future[String] = os.map {
     case "mac" => DefaultMacUrl
     case "win" => DefaultWinUrl
@@ -74,4 +83,16 @@ object ConfigStorage {
     }
 
   def saveUrls(urls:Seq[String]) = save(ParamSavedUrlConnection,urls.mkString(Separator))
+
+  def saveRunCommand(containerId: String, command: String): Future[Unit] = {
+    save(containerId, command)
+  }
+
+  def getRunCommand(containerId: String): Future[Option[String]] = get(containerId)
+    .map(Some(_))
+    .recover { case _ => None }
+
+  def removeRunCommand(containerId: String): Future[Unit] = {
+    remove(containerId)
+  }
 }

--- a/src/main/scala/ui/widgets/dialogs/ContainerRequestForm.scala
+++ b/src/main/scala/ui/widgets/dialogs/ContainerRequestForm.scala
@@ -1,5 +1,6 @@
 package ui.widgets.dialogs
 
+import api.ConfigStorage
 import japgolly.scalajs.react.vdom.prefix_<^._
 import japgolly.scalajs.react.{BackendScope, ReactComponentB, ReactEventI}
 import model._
@@ -178,6 +179,7 @@ object ContainerRequestForm {
           if (response.Id.isEmpty) {
             t.modState(s => s.copy(warnings = response.Warnings))
           } else {
+            ConfigStorage.saveRunCommand(response.Id, textCommand)
             dom.document.getElementById("open-modal-dialog").asInstanceOf[dom.raw.HTMLButtonElement].click()
             dom.setTimeout(() => t.props.actionsBackend.newContainerCreated(response.Id), 1) // delay after animation
           }

--- a/src/main/scala/util/ChromeApi.scala
+++ b/src/main/scala/util/ChromeApi.scala
@@ -24,6 +24,8 @@ object api extends js.GlobalScope {
     def set(map: js.Dynamic, callback: js.Function0[Any]): Unit = js.native
 
     def get(key: String, callback: js.Function1[js.Dynamic, Any]): Unit = js.native
+
+    def remove(key: String, callback: js.Function0[Any]): Unit = js.native
   }
 
   @js.native


### PR DESCRIPTION
Hi @felixgborrego, I also came across missing this feature (#58) few times so I tried to add it myself. The change is very light, were I:
- persist run command to local storage on container start
- display that command on container page (if exist)
- remove command when a container is removed

The only drawback I can see is that this feature will work only for newly created containers (because of persisting commands). 

Please let me know you think about it, I can make appropriate changes to meet your requirements. 
