### PR TITLE
Fix readme.md header for Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Any feedback is more than welcome!
 *  Bower
 *  Momentjs
 
-###Contributing
+### Contributing
 
 Compile and test it yourself:
 


### PR DESCRIPTION
GitHub changed their markdown rendering so headers require a space after the hash marks.